### PR TITLE
Fix 0 exposure time hang

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -108,7 +108,11 @@ function exif_key_translation($key, $value) {
 
       if (isset($tokens[1]))
       {
-        if ($tokens[1] > 0)
+        if ($tokens[0] == 0)
+        {
+          return '0 s';
+        }
+        elseif ($tokens[1] > 0)
         {
           while ($tokens[0] % 10 == 0)
           {


### PR DESCRIPTION
This fixes https://github.com/Piwigo/Piwigo/issues/307 - a phone of mine was producing pictures at some point which had an exposure time of 0 - the code here would loop forever since 0 % 10 is always 0.