### PR TITLE
Strict compare Flash Key

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -87,7 +87,7 @@ function exif_key_translation($key, $value) {
 	if (!(strpos($key, 'ExifVersion') === FALSE)) {
       return $value[1].'.'.$value[2];
    }
-   
+
    // Date Time Original
    if (!(strpos($key, 'DateTimeOriginal') === FALSE)) {
      // to fix bug:1862 the easiest way without releasing a new version of
@@ -119,7 +119,7 @@ function exif_key_translation($key, $value) {
             $tokens[0] = $tokens[0] / 10;
             $tokens[1] = $tokens[1] / 10;
           }
-          
+
           if ($tokens[1] == 1)
           {
             return $tokens[0].' s';
@@ -147,7 +147,7 @@ function exif_key_translation($key, $value) {
    }
 
    // flash
-   if (!(strpos($key, 'Flash') === FALSE)) {
+   if ($key === 'Flash') {
       // 1st bit is fired/did not fired
       if (($value & 1) > 0) {
          $retValue = l10n('yes');
@@ -258,7 +258,7 @@ function exif_key_translation($key, $value) {
    if (!(strpos($key, 'SubjectDistance') === FALSE)) {
       $tokens = explode('/', $value);
       if (isset($tokens[1]))
-      {  
+      {
         if ($tokens[1] > 0)
         {
           $distance = ($tokens[0]/$tokens[1]);
@@ -269,7 +269,7 @@ function exif_key_translation($key, $value) {
         }
       }
       else
-      {  
+      {
         $distance = $value;
       }
       return $distance.' m';
@@ -338,7 +338,7 @@ function exif_key_translation($key, $value) {
          default: return '';
       }
    }
-   
+
    // light source
    if (!(strpos($key, 'LightSource') === FALSE)) {
       switch ($value) {


### PR DESCRIPTION
As there is several other exif data beginning with Flash (like FlashStrength or FlashPixVersion which are string)

It should fix:https://github.com/plegall/Piwigo-exif_view/issues/3

If you like, I may submit a full PR to replace all the strpos in the file because it is the same for all other exif value.

For example FocalLength:
https://github.com/plegall/Piwigo-exif_view/blob/2e7451327d70b7fa5f9c6aa6ff2016a64771f289/main.inc.php#L227
There is no warning here because FocalLengthIn35mmFilm is check before and return...

Merci !



